### PR TITLE
Fix: Revert to ubuntu base image for adept_loan_mgt

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,6 @@
 name: Build and Publish to DockerHub
 on:
+  push:
   release:
     types: [published]
     
@@ -23,8 +24,8 @@ jobs:
     - name: Tag to release (-alpine)
       run: |
         docker tag $(cat BE_NAME):$(cat RELEASE_TAG)
-    - name: Push container to dockerhub
-      run: docker push --all-tags $(cat BE_NAME)
+    # - name: Push container to dockerhub
+    #   run: docker push --all-tags $(cat BE_NAME)
   publish-ubuntu:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/releases/')
@@ -44,5 +45,5 @@ jobs:
     - name: Tag to release (-ubuntu) + latest
       run: |
         docker tag $(cat BE_NAME):$(cat RELEASE_TAG) $(cat BE_NAME):latest
-    - name: Push container to dockerhub
-      run: docker push --all-tags $(cat BE_NAME)
+    # - name: Push container to dockerhub
+    #   run: docker push --all-tags $(cat BE_NAME)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,28 @@ on:
     types: [published]
     
 jobs:
-  publish:
+  publish-alpine:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/releases/')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Docker Login - Docker Hub
+      uses: Azure/docker-login@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Create Release tag
+      run: |
+        echo "bcliang/docker-libgourou" > BE_NAME
+        echo "${GITHUB_REF#refs/tags/releases/}-alpine" > RELEASE_TAG
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile-alpine --tag $(cat BE_NAME):$(cat RELEASE_TAG)
+    - name: Tag to release (-alpine)
+      run: |
+        docker tag $(cat BE_NAME):$(cat RELEASE_TAG)
+    - name: Push container to dockerhub
+      run: docker push --all-tags $(cat BE_NAME)
+  publish-ubuntu:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/releases/')
     steps:
@@ -18,11 +39,11 @@ jobs:
     - name: Create Release tag
       run: |
         echo "bcliang/docker-libgourou" > BE_NAME
-        echo "${GITHUB_REF#refs/tags/releases/}" > RELEASE_TAG
+        echo "${GITHUB_REF#refs/tags/releases/}-ubuntu" > RELEASE_TAG
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag $(cat BE_NAME):$(cat RELEASE_TAG)
-    - name: Tag to release + latest
-      run: | 
+      run: docker build . --file Dockerfile-ubuntu --tag $(cat BE_NAME):$(cat RELEASE_TAG)
+    - name: Tag to release (-ubuntu) + latest
+      run: |
         docker tag $(cat BE_NAME):$(cat RELEASE_TAG) $(cat BE_NAME):latest
     - name: Push container to dockerhub
       run: docker push --all-tags $(cat BE_NAME)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish-alpine:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/releases/')
+    # if: startsWith(github.ref, 'refs/tags/releases/')
     steps:
     - uses: actions/checkout@v4
     - name: Docker Login - Docker Hub
@@ -28,7 +28,7 @@ jobs:
     #   run: docker push --all-tags $(cat BE_NAME)
   publish-ubuntu:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/releases/')
+    # if: startsWith(github.ref, 'refs/tags/releases/')
     steps:
     - uses: actions/checkout@v4
     - name: Docker Login - Docker Hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish-alpine:
     runs-on: ubuntu-latest
-    # if: startsWith(github.ref, 'refs/tags/releases/')
+    if: startsWith(github.ref, 'refs/tags/releases/')
     steps:
     - uses: actions/checkout@v4
     - name: Docker Login - Docker Hub
@@ -28,7 +28,7 @@ jobs:
     #   run: docker push --all-tags $(cat BE_NAME)
   publish-ubuntu:
     runs-on: ubuntu-latest
-    # if: startsWith(github.ref, 'refs/tags/releases/')
+    if: startsWith(github.ref, 'refs/tags/releases/')
     steps:
     - uses: actions/checkout@v4
     - name: Docker Login - Docker Hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,5 @@
 name: Build and Publish to DockerHub
 on:
-  push:
   release:
     types: [published]
     
@@ -24,8 +23,8 @@ jobs:
     - name: Tag to release (-alpine)
       run: |
         docker tag $(cat BE_NAME):$(cat RELEASE_TAG) $(cat BE_NAME):alpine
-    # - name: Push container to dockerhub
-    #   run: docker push --all-tags $(cat BE_NAME)
+    - name: Push container to dockerhub
+      run: docker push --all-tags $(cat BE_NAME)
   publish-ubuntu:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/releases/')
@@ -46,6 +45,5 @@ jobs:
       run: |
         docker tag $(cat BE_NAME):$(cat RELEASE_TAG) $(cat BE_NAME):ubuntu
         docker tag $(cat BE_NAME):$(cat RELEASE_TAG) $(cat BE_NAME):latest
-        
-    # - name: Push container to dockerhub
-    #   run: docker push --all-tags $(cat BE_NAME)
+    - name: Push container to dockerhub
+      run: docker push --all-tags $(cat BE_NAME)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/releases/')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Docker Login - Docker Hub
-      uses: Azure/docker-login@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -29,10 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/releases/')
     steps:
-    - uses: actions/checkout@v2
-    
+    - uses: actions/checkout@v4
     - name: Docker Login - Docker Hub
-      uses: Azure/docker-login@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
       run: docker build . --file Dockerfile-alpine --tag $(cat BE_NAME):$(cat RELEASE_TAG)
     - name: Tag to release (-alpine)
       run: |
-        docker tag $(cat BE_NAME):$(cat RELEASE_TAG)
+        docker tag $(cat BE_NAME):$(cat RELEASE_TAG) $(cat BE_NAME):alpine
     # - name: Push container to dockerhub
     #   run: docker push --all-tags $(cat BE_NAME)
   publish-ubuntu:
@@ -44,6 +44,8 @@ jobs:
       run: docker build . --file Dockerfile-ubuntu --tag $(cat BE_NAME):$(cat RELEASE_TAG)
     - name: Tag to release (-ubuntu) + latest
       run: |
+        docker tag $(cat BE_NAME):$(cat RELEASE_TAG) $(cat BE_NAME):ubuntu
         docker tag $(cat BE_NAME):$(cat RELEASE_TAG) $(cat BE_NAME):latest
+        
     # - name: Push container to dockerhub
     #   run: docker push --all-tags $(cat BE_NAME)

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -16,7 +16,6 @@ RUN git clone git://soutade.fr/libgourou.git \
   && cd libgourou \
   && make BUILD_STATIC=1
 
-
 # copy from builder to runtime image
 FROM alpine:latest
 
@@ -29,6 +28,7 @@ RUN apk add --no-cache \
 COPY --from=builder /usr/src/libgourou/utils/acsmdownloader \
                     /usr/src/libgourou/utils/adept_activate \
                     /usr/src/libgourou/utils/adept_remove \
+                    /usr/src/libgourou/utils/adept_loan_mgt \
                     /usr/local/bin/
 
 WORKDIR /home/libgourou

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -1,0 +1,42 @@
+FROM ubuntu:jammy AS builder
+
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive TZ="America\Los_Angeles" \
+  apt-get install -y \
+  build-essential \
+  bash \
+  git \
+  wget \
+  libzip-dev \
+  libssl-dev \
+  libcurl4-gnutls-dev \
+  libpugixml-dev
+
+WORKDIR /usr/src
+# RUN apt-get install -y valgrind
+
+RUN git clone git://soutade.fr/libgourou.git \
+  && cd libgourou \
+  && make BUILD_STATIC=1 STATIC_UTILS=1
+
+FROM ubuntu:jammy as release
+
+COPY --from=builder /usr/src/libgourou/utils/acsmdownloader \
+                    /usr/src/libgourou/utils/adept_activate \
+                    /usr/src/libgourou/utils/adept_remove \
+                    /usr/src/libgourou/utils/adept_loan_mgt \
+                    /usr/local/bin/
+
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive TZ="America\Los_Angeles" \ 
+  && apt-get install -y \
+  libpugixml1v5 \
+  libzip4 \
+  libssl3 \
+  libcurl4-gnutls-dev \
+  && apt-get autoclean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts /home/libgourou
+WORKDIR /home/libgourou
+ENTRYPOINT ["/bin/bash", "/home/libgourou/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ This container compiles the reference implementation utilities for libgourou (ma
 ### Local Build
 
 ```bash
-> docker build . -t bcliang/docker-libgourou
+> docker build . -f Dockerfile-ubuntu -t bcliang/docker-libgourou
+```
+
+or on alpine:
+```bash
+> docker build . -f Dockerfile-alpine -t bcliang/docker-libgourou
 ```
 
 ### DockerHub
@@ -30,6 +35,8 @@ This container compiles the reference implementation utilities for libgourou (ma
 ```bash
 > docker pull bcliang/docker-libgourou:latest
 ```
+
+The `:latest` tag will pull the `:ubuntu` image. Use `:ubuntu` or `:alpine` to specify the desired base image (warning: segmentation faults when running the alpine build in `0.8.4`).
 
 ## Usage
 
@@ -103,7 +110,7 @@ A "de-DRM" bash script is provided (`./scripts/dedrm.sh`) to simplify running an
 To launch an interactive terminal with access to the libgourou utils:
 ```bash
 > dedrm
-!!!    WARNING: no ADEPT keys detected (argument $2, or "/home/brad/.config/adept").
+!!!    WARNING: no ADEPT keys detected (argument $2, or "$HOME_DIR/.config/adept").
 !!!    Launching interactive terminal for credentials creation (device activation). Run this:
 
  > adept_activate --random-serial \
@@ -112,7 +119,7 @@ To launch an interactive terminal with access to the libgourou utils:
        --output-dir files/adept
 
 !!!     (*) use --anonymous in place of --username, --password if you do not have an ADE account.
-!!!     (*) credentials will be saved in the following path: "/home/brad/repos/docker-libgourou/adept"
+!!!     (*) credentials will be saved in the following path: "$(pwd)/adept"
 
 !!!    WARNING: no ACSM file detected (argument $1).
 !!!    Launching interactive terminal for manual loan management. Example commands below:


### PR DESCRIPTION
From #13, the `Dockerfile` missed copying the utility software for managing ADE loans (`adept_loan_mgt`) over from the builder image. After inclusion, the utility was present but not functional due to uncaught segmentation faults. For now, I wasn't able to resolve the errors.

This PR reverts the release container back to `ubuntu` `jammy`. The `alpine` flavor will continue to be built by the github action (including the compiled `adept_loan_mgt` utility), but the segmentation fault issues remain unresolved.

Fixes:
- Add the `adept_loan_mgt` utility to the published container

Changes:
- Dockerfiles for both `ubuntu` and `alpine`
- Update github action to build both `ubuntu` and `alpine` images
- Pull latest master from mainline (currently tagged to `0.8.4`):
   - improved HTTP response handling 
   - some OS-specific changes for windows / android)

Side-effect: 
- The extracted container size has increased due to the base image (`19.5MB` vs. `88.3MB`)
