### PR TITLE
Fix libgourou url and conflicting options in `adept_remove`

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -12,7 +12,7 @@ RUN apk add g++ \
 
 WORKDIR /usr/src
 
-RUN git clone git://soutade.fr/libgourou.git \
+RUN git clone https://forge.soutade.fr/soutade/libgourou.git \
   && cd libgourou \
   && make BUILD_STATIC=1
 

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -15,7 +15,7 @@ RUN apt-get update && \
 WORKDIR /usr/src
 # RUN apt-get install -y valgrind
 
-RUN git clone git://soutade.fr/libgourou.git \
+RUN git clone https://forge.soutade.fr/soutade/libgourou.git \
   && cd libgourou \
   && make BUILD_STATIC=1 STATIC_UTILS=1
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -13,6 +13,5 @@ mv "$OUTPUT_FILE" "encrypted_file.drm"
 
 adept_remove \
   --adept-directory .adept \
-  --output-dir files \
-  --output-file "$OUTPUT_FILE" \
+  --output-file files/"$OUTPUT_FILE" \
   "encrypted_file.drm"


### PR DESCRIPTION
Hi,

1. Update the libgourou git URL to the correct one.
2. Fix conflicting flags for `adept_remove` that resulted in the following error:

```
Error : you cannot use both -o and -O
```